### PR TITLE
Add value discard check

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,10 @@ val circeVersion = "0.12.3"
 
 val commonSettings = Seq(
   scalaVersion := "2.13.2",
-  scalacOptions += s"-Yimports:${imports.mkString(",")}",
+  scalacOptions ++= Seq(
+    s"-Yimports:${imports.mkString(",")}",
+    "-Ywarn-value-discard"
+  ),
 
   addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.11.0" cross CrossVersion.full),
 


### PR DESCRIPTION
I got bitten by `map`ing instead of `flatMap`ing in one of the exercises. The compiler should have caught it but didn't. 

This compiler flag will now catch it, if anyone makes the same mistake.

For example if you replace `>>=` with `map` here: https://github.com/benhutchison/modesofcomposition/blob/master/solution/src/main/scala/modesofcomposition/OrderProcessor.scala#L75
